### PR TITLE
fix: build vcdimager

### DIFF
--- a/org.gnome.Brasero.yaml
+++ b/org.gnome.Brasero.yaml
@@ -227,6 +227,14 @@ modules:
           type: anitya
           project-id: 16033
           url-template: https://ftp.gnu.org/gnu/vcdimager/vcdimager-$version.tar.gz
+    modules:
+      - name: popt
+        config-opts:
+          - --disable-static
+        sources:
+        - type: archive
+          url: https://ftp.osuosl.org/pub/rpm/popt/releases/popt-1.x/popt-1.19.tar.gz
+          sha512: 5d1b6a15337e4cd5991817c1957f97fc4ed98659870017c08f26f754e34add31d639d55ee77ca31f29bb631c0b53368c1893bd96cf76422d257f7997a11f6466
 
   - name: brasero
     config-opts:


### PR DESCRIPTION
The vcdimager CLI hasn't been built since the change to GNOME SDK 46, as it removes libpopt. This adds that back.